### PR TITLE
fixing Dockerfile: opencv version will be assigned properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yum install -y python36u-pip
 RUN mkdir -p /packages/opencv-python-3.6/python/lib/python3.6/site-packages
 
 # Install Python packages
-RUN echo "opencv-python=4.1.0.25" >> /packages/requirements.txt
+RUN echo "opencv-python==4.1.0.25" >> /packages/requirements.txt
 RUN pip3.7 install -r /packages/requirements.txt -t /packages/opencv-python-3.7/python/lib/python3.7/site-packages
 RUN pip3.6 install -r /packages/requirements.txt -t /packages/opencv-python-3.6/python/lib/python3.6/site-packages
 
@@ -28,3 +28,4 @@ RUN zip -r9 /packages/cv2-python36.zip .
 WORKDIR /packages/
 RUN rm -rf /packages/opencv-python-3.7/
 RUN rm -rf /packages/opencv-python-3.6/
+


### PR DESCRIPTION
When building the Docker image, the following error message is printed:

```
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3.7 install --user` instead.
Invalid requirement: 'opencv-python=4.1.0.25'
= is not a valid operator. Did you mean == ?
```