### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN mkdir /packages
 RUN echo "opencv-python" >> /packages/requirements.txt
 RUN mkdir -p /packages/opencv-python-3.7/python/lib/python3.7/site-packages
 RUN mkdir -p /packages/opencv-python-3.8/python/lib/python3.8/site-packages
+RUN pip3.7 install --upgrade pip
 RUN pip3.7 install -r /packages/requirements.txt -t /packages/opencv-python-3.7/python/lib/python3.7/site-packages
+RUN pip3.8 install --upgrade pip
 RUN pip3.8 install -r /packages/requirements.txt -t /packages/opencv-python-3.8/python/lib/python3.8/site-packages
 
 


### PR DESCRIPTION
Errors out in current state with: `ModuleNotFoundError: No module named 'skbuild'` when installing opencv. Need to update pip for both versions: https://github.com/skvark/opencv-python#frequently-asked-questions